### PR TITLE
Enable beman-tidy --require-all

### DIFF
--- a/.beman-tidy.yaml
+++ b/.beman-tidy.yaml
@@ -4,7 +4,7 @@
 # Check documentation for beman-tidy here:
 # https://github.com/bemanproject/beman-tidy/blob/main/README.md
 
-disabled_rules:
-    # None
+disabled_rules: []
+
 ignored_paths:
-    # None
+    - infra/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,5 +46,6 @@ repos:
     rev: v0.5.1
     hooks:
     - id: beman-tidy
+      args: [".", "--verbose", "--require-all"]
 
 exclude: 'cookiecutter/|infra/|port/'


### PR DESCRIPTION
## Summary

- Fix `.beman-tidy.yaml` (`ignored_paths: [infra/]`, `disabled_rules: []`)
- Enable `beman-tidy --require-all` in pre-commit (`args: [".", "--verbose", "--require-all"]`)
- Bump `beman-tidy` to **v0.5.2** (merged latest `main`)

## Context

- Default mode is already enabled on `main` (v0.5.2)
- Tracking issue: bemanproject/beman-tidy#331

## Test plan

- [x] `pre-commit run beman-tidy --all-files` passes locally
- [x] CI green